### PR TITLE
Explicitly reference the consul cookbook from the recipe

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,4 +2,3 @@ source 'http://berks-api.optoro.io'
 metadata
 
 cookbook 'apt'
-cookbook 'consul'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'devops@optoro.com'
 license 'MIT'
 description 'Installs Consul'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.0.14'
+version '0.0.15'
 
 supports 'ubuntu', '= 14.04'
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -2,7 +2,7 @@ node.default['consul']['config']['bootstrap_expect'] = node['optoro_consul']['bo
 node.default['consul']['config']['server'] = true
 node.default['consul']['config']['start_join'] = node['optoro_consul']['servers']
 node.default['consul']['config']['enable_syslog'] = true
-include_recipe 'optoro_consul::default'
+include_recipe 'consul'
 
 consul_ui 'consul_ui' do
   version '0.6.3'

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -1,4 +1,4 @@
-include_recipe 'optoro_consul::default'
+include_recipe 'consul'
 
 consul_definition node['optoro_consul']['service']['name'] do
   type 'service'


### PR DESCRIPTION
The consul_ui resource is not being recongnized on nodes during the chef
run. I am going to try and reference the consul cookbook from the recipe
to make sure the consul cookbook and resources are available.