### PR TITLE
Use ipaddress attribute instead of fqdn

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs Consul'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://optoro.atlassian.net/secure/Dashboard.jspa'
 source_url 'https://github.com/optoro-devops/optoro_consul'
-version '0.1.3'
+version '0.1.4'
 
 supports 'ubuntu', '= 14.04'
 

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -17,7 +17,7 @@ action :create do
   params = {
     name: name,
     port: new_resource.port,
-    address: node['fqdn']
+    address: node['ipaddress']
   }
 
   params = DeepMerge.merge(params, new_resource.params)


### PR DESCRIPTION
Consul DNS resolution treats the fqdn like a CNAME which it does not
automatically resolve. Using the ip address allows us the behavior that
is desired.